### PR TITLE
feat: fix naming scheme and add lighter navy variants

### DIFF
--- a/flybywire-tailwind-config.js
+++ b/flybywire-tailwind-config.js
@@ -30,7 +30,7 @@ module.exports = {
                 colors: {
                     teal: {
                         'DEFAULT': '#00c2cc',
-                        'regular:': '#00c2cc',
+                        'regular': '#00c2cc',
                         // deprecated
                         'light': '#00c2cc',
                         'regular-contrast': '#00afb7',

--- a/flybywire-tailwind-config.js
+++ b/flybywire-tailwind-config.js
@@ -30,7 +30,11 @@ module.exports = {
                 colors: {
                     teal: {
                         'DEFAULT': '#00c2cc',
+                        'regular:': '#00c2cc',
+                        // deprecated
                         'light': '#00c2cc',
+                        'regular-contrast': '#00afb7',
+                        // deprecated
                         'light-contrast': '#00afb7',
                         'medium': '#009ba2',
                         'medium-contrast': '#00888e',
@@ -53,7 +57,13 @@ module.exports = {
                     },
                     navy: {
                         'DEFAULT': '#1b2434',
+                        'lightest': '#273347',
+                        'lighter': '#222c3d',
+                        'regular': '#1b2434',
+                        // deprecated
                         'light': '#1b2434',
+                        'regular-contrast': '#18202f',
+                        // deprecated
                         'light-contrast': '#18202f',
                         'medium': '#161d2a',
                         'medium-contrast': '#131924',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flybywiresim/tailwind-config",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TailwindCSS configuration used by FlyByWire projects",
   "main": "flybywire-tailwind-config.js",
   "repository": {


### PR DESCRIPTION
* Change `light[-contrast]` to `regular[-contrast]`. Keeps old names for backcompat, but they are deprecated
*  Add lighter navy vairants for use on /website and /installer